### PR TITLE
Adds Recorder2 for by data analysis. Adds docstrings.

### DIFF
--- a/src/data_summarize.py
+++ b/src/data_summarize.py
@@ -4,6 +4,19 @@ from record_parser import parse_record_line_with_filter
 
 
 class Recorder:
+    """Records input TRANSACTION_AMT featuring fast median finding
+
+    Attributes
+    ----------
+    heaps : tuple of lists
+        Two min_heaps for numbers smaller / larger than median.
+
+    counts : int
+        Counts of input numbers
+    total : int
+        Sum of total numbers
+
+    """
 
     def __init__(self):
         self.heaps = [], []
@@ -11,63 +24,209 @@ class Recorder:
         self.total = 0
 
     def addNum(self, num):
+        """Adds number into Recorder
+
+        Complexity O(log n)
+
+        Parameters
+        ----------
+        num : int
+            Number to be added into Recorder
+
+        Returns
+        -------
+        None
+
+        """
         self.counts += 1
         self.total += num
         small, large = self.heaps
         heappush(small, -heappushpop(large, num))
+        # Make sure large heap is no shorter than small
         if len(large) < len(small):
             heappush(large, -heappop(small))
 
     def findMedian(self):
+        """Finds median.
+
+        Median should be root of larger number heap or average of the two roots.
+        Complexity O(1)
+
+        Returns
+        -------
+        int
+            Running median of all input numbers
+
+        """
         small, large = self.heaps
         if len(large) > len(small):
             return int(large[0])
         return int(round((large[0] - small[0]) / 2.0))
 
 
-def aggregate_by_key(recorder_dict, input_record, key):
+class Recorder2:
+    """Records input TRANSACTION_AMT featuring fast number adding
+
+    Attributes
+    ----------
+    series : list
+        One list with all input numbers unsorted.
+    counts : int
+        Counts of input numbers
+    total : int
+        Sum of total numbers
+
+    """
+
+    def __init__(self):
+        self.series = []
+        self.counts = 0
+        self.total = 0
+
+    def addNum(self, num):
+        """Adds number to the list
+
+        Complexity O(1)
+
+        Parameters
+        ----------
+        num : int
+            Input number
+
+        Returns
+        -------
+        None
+
+        """
+        self.counts += 1
+        self.total += num
+        self.series.append(num)
+
+    def findMedian(self):
+        """Finds median of all input numbers
+
+        Complexity should dominated by Python sorted, O(n * log n)
+
+        Returns
+        -------
+        int
+            Median of all input numbers
+
+        """
+        n = self.counts
+        if n < 1:
+            return None
+        if n % 2 == 1:
+            return int(sorted(self.series)[n // 2])
+        else:
+            return int(round(sum(sorted(self.series)[n // 2 - 1:n // 2 + 1]) / 2.0))
+
+
+def aggregate_by_key(recorder_dict, input_record, key, data_recorder=Recorder, string_output=True):
+    """Adds input record into the corresponding data recorder and returns string to write.
+
+    Parameters
+    ----------
+    recorder_dict : dict
+        the nested dictionary storing data recorders
+    input_record : dict
+        the dictionary of record parsed from one line of raw input txt file
+    key : str
+        the field (ZIP_CODE or TRANSACTION_DT) according to which to aggregate data
+    data_recorder : classobj
+        the type of class object (Recorder or Recorder2) to store input record
+    string_output : bool
+        False mutes string output
+
+    Returns
+    -------
+    None or str
+        If input is invalid or output is muted, returns None. Otherwise returns the string to be written into file.
+
+    """
     cmte_id = input_record['CMTE_ID']
     key_value = input_record[key]
+
+    # Skips record with invalid field of interest, e.g. analyzing by zip but record has invalid zip
     if key_value is None:
         return
+
+    # Opens up new dictionary keys for new incoming id or field value
     if cmte_id not in recorder_dict.keys():
         recorder_dict[cmte_id] = {}
-        recorder_dict[cmte_id][key_value] = Recorder()
+        recorder_dict[cmte_id][key_value] = data_recorder()
     elif key_value not in recorder_dict[cmte_id].keys():
-        recorder_dict[cmte_id][key_value] = Recorder()
+        recorder_dict[cmte_id][key_value] = data_recorder()
+
     recorder_dict[cmte_id][key_value].addNum(input_record['TRANSACTION_AMT'])
-    output_str = "{id}|{kv}|{median}|{counts}|{total}".format(
-        id=cmte_id, kv=key_value, median=recorder_dict[cmte_id][key_value].findMedian(),
-        counts=recorder_dict[cmte_id][key_value].counts, total=recorder_dict[cmte_id][key_value].total
-    )
-    return output_str
+
+    if string_output:
+        output_str = "{id}|{kv}|{median}|{counts}|{total}".format(
+            id=cmte_id, kv=key_value, median=recorder_dict[cmte_id][key_value].findMedian(),
+            counts=recorder_dict[cmte_id][key_value].counts, total=recorder_dict[cmte_id][key_value].total
+        )
+        return output_str
 
 
 def stream_in_out_by_zip(input_file_path, output_file_path):
-    recorder_dict = {}
+    """Reads input txt file line by line, calculates running median, and writes to file for every valid record line.
+
+    For use of processing data only by zip.
+
+    Parameters
+    ----------
+    input_file_path : str
+        Path to input txt file
+    output_file_path
+        Path to output txt file
+
+    Returns
+    -------
+    None
+
+    """
+
+    recorder_dict = {}  # Nested dictionary to store recorders.
+
     with open(input_file_path, 'r') as input_file, open(output_file_path, 'a') as output_file:
         record_line = input_file.readline()
-        while record_line:
+        while record_line:  # Reads until file ends
             record_dict = parse_record_line_with_filter(record_line)
-            if record_dict is not None:
+            if record_dict is not None:  # Valid record
                 output_str = aggregate_by_key(recorder_dict, record_dict, key="ZIP_CODE")
-                if output_str:
+                if output_str:  # Valid zip code
                     output_file.write(output_str+'\n')
             record_line = input_file.readline()
 
 
 def batch_in_out_by_date(input_file_path, output_file_path):
-    recorder_dict = {}
+    """Reads all input records, calculates medians for each combination and writes to file in the end.
+
+    Parameters
+    ----------
+    input_file_path : str
+        Path to input txt file
+    output_file_path : str
+        Path to output txt file
+
+    Returns
+    -------
+    None
+
+    """
+
+    recorder_dict = {}  # Nested dictionary to store recorders.
     with open(input_file_path, 'r') as input_file:
         record_line = input_file.readline()
-        while record_line:
+        while record_line:  # Reads until file ends
             record_dict = parse_record_line_with_filter(record_line)
-            if record_dict is not None:
-                aggregate_by_key(recorder_dict, record_dict, key="TRANSACTION_DT")
+            if record_dict is not None:  # Valid record
+                aggregate_by_key(recorder_dict, record_dict, key="TRANSACTION_DT",
+                                 data_recorder=Recorder2, string_output=False)
             record_line = input_file.readline()
     with open(output_file_path, 'a') as output_file:
-        for cmte_id in sorted(recorder_dict.iterkeys()):
-            for date in sorted(recorder_dict[cmte_id].iterkeys()):
+        for cmte_id in sorted(recorder_dict.iterkeys()):  # Sort CMTE_ID alphabetically
+            for date in sorted(recorder_dict[cmte_id].iterkeys()):  # Sort TRANSACTION_DT chronologically
                 output_str = "{id}|{dt}|{median}|{counts}|{total}".format(
                     id=cmte_id, dt=date, median=recorder_dict[cmte_id][date].findMedian(),
                     counts=recorder_dict[cmte_id][date].counts, total=recorder_dict[cmte_id][date].total
@@ -76,21 +235,46 @@ def batch_in_out_by_date(input_file_path, output_file_path):
 
 
 def combined_zip_and_date_processing(input_file_path, zip_file_path, date_file_path):
+    """Combines analysis by zip and by date to skip one round of file reading.
+
+    Parameters
+    ----------
+    input_file_path : str
+        Path to input txt file
+    zip_file_path : str
+        Path to output txt file for zip analysis
+    date_file_path : str
+        Path to output txt file for date analysis
+
+    Returns
+    -------
+    None
+
+    """
+
+    # Nested dictionaries for the two analyses, by zip and by date
     recorder_dict_zip = {}
     recorder_dict_date = {}
+
+    # Stream in and stream out for zip analysis
     with open(input_file_path, 'r') as input_file, open(zip_file_path, 'a') as output_file:
         record_line = input_file.readline()
-        while record_line:
+        while record_line:  # Reads until file ends
             record_dict = parse_record_line_with_filter(record_line)
-            if record_dict is not None:
+            if record_dict is not None:  # Valid record
+                # for zip analysis
                 output_str = aggregate_by_key(recorder_dict_zip, record_dict, key="ZIP_CODE")
-                aggregate_by_key(recorder_dict_date, record_dict, key="TRANSACTION_DT")
-                if output_str:
+                # for date analysis
+                aggregate_by_key(recorder_dict_date, record_dict, key="TRANSACTION_DT",
+                                 data_recorder=Recorder2, string_output=False)
+                if output_str:  # Valid zip code
                     output_file.write(output_str+'\n')
             record_line = input_file.readline()
+
+    # Writes date analysis after all date is in
     with open(date_file_path, 'a') as output_file:
-        for cmte_id in sorted(recorder_dict_date.iterkeys()):
-            for date in sorted(recorder_dict_date[cmte_id].iterkeys()):
+        for cmte_id in sorted(recorder_dict_date.iterkeys()):  # Sort CMTE_ID alphabetically
+            for date in sorted(recorder_dict_date[cmte_id].iterkeys()):  # Sort TRANSACTION_DT chronologically
                 output_str = "{id}|{dt}|{median}|{counts}|{total}".format(
                     id=cmte_id, dt=date, median=recorder_dict_date[cmte_id][date].findMedian(),
                     counts=recorder_dict_date[cmte_id][date].counts, total=recorder_dict_date[cmte_id][date].total

--- a/src/record_parser.py
+++ b/src/record_parser.py
@@ -2,7 +2,7 @@ import os
 import os.path as path
 import datetime
 
-# Fields of interest in each line of record with corresponding position
+# Fields of interest in each line of record with corresponding position according to the format described by FEC
 TARGET_FIELDS = {"CMTE_ID": 0,
                  "ZIP_CODE": 10,
                  "TRANSACTION_DT": 13,
@@ -11,17 +11,18 @@ TARGET_FIELDS = {"CMTE_ID": 0,
 
 
 def parse_record_line(record_line):
-    """
-    Parses input string of record into a dictionary with information of interest
+    """Parses input string of record into a dictionary with information of interest
+
     Parameters
     ----------
-    record_line : string
+    record_line : str
         A string for one line of record, separated by bars
 
     Returns
     -------
     dict
-        The dictionary with info of interest
+        The dictionary with info of interest, each field is str
+
     """
     line_splited = record_line.split("|")
     record_dict = {}
@@ -31,11 +32,35 @@ def parse_record_line(record_line):
 
 
 def is_valid_other_id(other_id):
+    """Checks if OTHER_ID is empty
+
+    Parameters
+    ----------
+    other_id : str
+
+    Returns
+    -------
+    bool
+        True if valid, False if not.
+
+    """
     return not bool(other_id)
 
 
 def is_valid_trans_date(trans_date):
-    if len(trans_date) != 8:
+    """Checks if TRANSACTION_DT is valid, not empty or malformed
+
+    Parameters
+    ----------
+    trans_date : str
+
+    Returns
+    -------
+    bool
+        True if valid, False if not.
+
+    """
+    if len(trans_date) != 8:  # MMDDYYY is 8 digits
         return False
     try:
         datetime.datetime.strptime(trans_date, "%m%d%Y")
@@ -45,6 +70,18 @@ def is_valid_trans_date(trans_date):
 
 
 def is_valid_zip_code(zip_code):
+    """Checks if ZIP_CODE is valid, at least 5 digits
+
+    Parameters
+    ----------
+    zip_code : str
+
+    Returns
+    -------
+    bool
+        True if valid, False if not.
+
+    """
     if len(zip_code) < 5:
         return False
     else:
@@ -52,14 +89,51 @@ def is_valid_zip_code(zip_code):
 
 
 def is_valid_cmte_id(cmte_id):
+    """Checks if CMTE_ID is valid, not empty
+
+    Parameters
+    ----------
+    cmte_id : str
+
+    Returns
+    -------
+    bool
+        True if valid, False if not.
+
+    """
     return bool(cmte_id)
 
 
 def is_valid_trans_amt(trans_amt):
+    """Checks if TRANSACTION_AMT is valid, not empty.
+
+    Parameters
+    ----------
+    trans_amt : str
+
+    Returns
+    -------
+    bool
+        True if valid, False if not.
+
+    """
     return bool(trans_amt)
 
 
 def is_valid_record(record_dict):
+    """Checks if a dictionary of record is valid, with non-empty CMTE_ID, TRANSACTION_AMT and empty OTHER_ID.
+
+    Parameters
+    ----------
+    record_dict : dict
+        Dictionaries parsed from one line of record
+
+    Returns
+    -------
+    bool
+        True if valid, False if not.
+
+    """
     cmte_id = record_dict['CMTE_ID']
     other_id = record_dict['OTHER_ID']
     trans_amt = record_dict['TRANSACTION_AMT']
@@ -70,19 +144,37 @@ def is_valid_record(record_dict):
 
 
 def parse_record_line_with_filter(record_line):
+    """Takes in one line of record, checks if record conform with input considerations, and outputs valid record.
+
+    Parameters
+    ----------
+    record_line : str
+        One line of record read from raw input txt file
+
+    Returns
+    -------
+    None or dict
+        If record is valid, return record parsed in dictionary form. Otherwise None.
+
+    """
     record_dict = parse_record_line(record_line)
 
+    # check validness
     if not is_valid_record(record_dict):
         return None
-
     if is_valid_zip_code(record_dict['ZIP_CODE']):
+        # crop the first 5 digits
         record_dict['ZIP_CODE'] = record_dict['ZIP_CODE'][:5]
     else:
+        # set invalid zip codes to None, but still passing on for analysis
         record_dict['ZIP_CODE'] = None
 
     if not is_valid_trans_date(record_dict['TRANSACTION_DT']):
+        # set invalid dates to None, but still passing on for analysis
         record_dict['TRANSACTION_DT'] = None
 
+    # OTHER_ID is no longer needed after validness check
     record_dict.pop('OTHER_ID')
+    # make TRANSACTION_AMT integer for analysis
     record_dict['TRANSACTION_AMT'] = int(record_dict['TRANSACTION_AMT'])
     return record_dict


### PR DESCRIPTION
By-date analysis does not need to calculate running median. To optimize, `Recorder2.addNum` should be inexpensive. An more expensive `findMedian` should be acceptable since it will be executed only once each. 